### PR TITLE
Removed recommendation to use Intel Compiler

### DIFF
--- a/documentation/md_getting-started.html
+++ b/documentation/md_getting-started.html
@@ -177,28 +177,12 @@ Build Environment</h1>
 <summary >
 Windows</summary>
 <p></p>
-<p>On Windows, you can either use Intel Compilers with the standard Microsoft toolchain, <a href="https://docs.docker.com/get-docker/">Docker</a> or the <a href="https://docs.microsoft.com/en-us/windows/wsl/">Windows Subsystem for Linux (WSL)</a> for a Linux experience.</p>
-<details >
-<summary >
-Windows + Intel (Native)</summary>
-<p></p>
-<p>Install the latest version of:</p><ul>
-<li><a href="https://visualstudio.microsoft.com/">Microsoft Visual Studio Community</a></li>
-<li><a href="https://www.intel.com/content/www/us/en/developer/tools/oneapi/base-toolkit-download.html">Intel® oneAPI Base Toolkit</a></li>
-<li><a href="https://www.intel.com/content/www/us/en/developer/tools/oneapi/hpc-toolkit-download.html">Intel® oneAPI HPC Toolkit</a></li>
-</ul>
-<p>Then, in order to initialize your development environment, open a terminal window and run: </p><div class="fragment"><div class="line">&quot;C:\Program Files (x86)\Intel\oneAPI\setvars.bat&quot;</div>
-</div><!-- fragment --><p>To follow this guide, please replace <code>./mfc.sh</code> with <code>mfc.bat</code> when running any commands. <code>./mfc.sh</code> is intended Unix-like systems. You will also have access to the <code>.sln</code> Microsoft Visual Studio solution files for an IDE (Integrated Development Environment).</p>
-<p></p>
-</details>
-<details >
-<summary >
-Windows + WSL</summary>
+<p>On Windows, you can use the <a href="https://docs.microsoft.com/en-us/windows/wsl/">Windows Subsystem for Linux (WSL)</a></p>
 <p></p>
 <p>Install the latest version of the <a href="https://docs.microsoft.com/en-us/windows/wsl/">Windows Subsystem for Linux (WSL)</a> as well as a distribution such as Ubuntu which can be found <a href="https://apps.microsoft.com/store/detail/ubuntu/9PDXGNCFSCZV">here</a>. Acquiring an interactive session is as simple as typing <code>wsl</code> in your command prompt, or alternatively, selecting the distribution from the dropdown menu available in the <a href="https://apps.microsoft.com/store/detail/windows-terminal/9N0DX20HK701">Microsoft Terminal</a>.</p>
 <p>You can now follow the appropriate instructions for your distribution.</p>
 <p></p>
-</details>
+
 <p></p>
 </details>
 <details >


### PR DESCRIPTION
The repository does not function properly on Windows using Visual Studio + the Intel compiler - this makes sense as the compiler is deprecated and it is generally much easier to just use WSL. The documentation was edited to remove the recommendation to use the Intel compiler on Windows machines due to the lack of function.